### PR TITLE
Movie details - introduce dispatcher

### DIFF
--- a/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsViewModel.kt
+++ b/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsViewModel.kt
@@ -29,8 +29,8 @@ import com.jpp.mpmoviedetails.MovieDetailsInteractor.MovieDetailEvent.AppLanguag
 import com.jpp.mpmoviedetails.MovieDetailsInteractor.MovieDetailEvent.NotConnectedToNetwork
 import com.jpp.mpmoviedetails.MovieDetailsInteractor.MovieDetailEvent.Success
 import com.jpp.mpmoviedetails.MovieDetailsInteractor.MovieDetailEvent.UnknownError
+import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -46,7 +46,8 @@ import kotlinx.coroutines.withContext
  * and the view state being shown to the user.
  */
 class MovieDetailsViewModel @Inject constructor(
-    private val movieDetailsInteractor: MovieDetailsInteractor
+        private val movieDetailsInteractor: MovieDetailsInteractor,
+        private val ioDispatcher: CoroutineDispatcher
 ) : MPViewModel() {
 
     private val _viewState = MediatorLiveData<MovieDetailViewState>()
@@ -148,7 +149,7 @@ class MovieDetailsViewModel @Inject constructor(
      */
     private fun withMovieDetailsInteractor(action: MovieDetailsInteractor.() -> Unit) {
         viewModelScope.launch {
-            withContext(Dispatchers.IO) {
+            withContext(ioDispatcher) {
                 action(movieDetailsInteractor)
             }
         }
@@ -160,7 +161,7 @@ class MovieDetailsViewModel @Inject constructor(
      */
     private fun mapMovieDetails(domainDetail: MovieDetail, imageUrl: String) {
         viewModelScope.launch {
-            withContext(Dispatchers.IO) {
+            withContext(ioDispatcher) {
                 with(domainDetail) {
                     MovieDetailViewState.showDetails(
                             movieImageUrl = imageUrl,

--- a/features/mpmoviedetails/src/test/java/com/jpp/mpmoviedetails/MovieDetailsViewModelTest.kt
+++ b/features/mpmoviedetails/src/test/java/com/jpp/mpmoviedetails/MovieDetailsViewModelTest.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -39,7 +38,10 @@ class MovieDetailsViewModelTest {
     fun setUp() {
         every { interactor.movieDetailEvents } returns lvInteractorEvents
 
-        subject = MovieDetailsViewModel(interactor)
+        subject = MovieDetailsViewModel(
+                interactor,
+                CoroutineTestExtension.testDispatcher
+        )
     }
 
     @Test
@@ -91,12 +93,7 @@ class MovieDetailsViewModelTest {
         verify { interactor.fetchMovieDetail(10.0) }
     }
 
-    /*
-     * TODO I need to check exactly what's happening with this UT. Don't want to waste
-     *  time since I'm going to refactor by eliminating the interactor layers.
-     */
     @Test
-    @Disabled
     fun `Should execute GetMovieDetailsUseCase, adapt result to UI model and post value on init`() {
         var viewStatePosted: MovieDetailViewState? = null
         val movieDetailId = 12.0


### PR DESCRIPTION
This commit updates `MovieDetailsViewModel` to use
an injectable `CoroutineDispatcher` instead of hardcoding
`Dispatchers.IO`.
This replacement facilitates the unit testing of the ViewModel and
that is why `MovieDetailsViewModelTest` is updated and all disabled
tests are re-enabled.
