### PR TITLE
MovieDetailsViewModel uses SavedStateHandle

### DIFF
--- a/app/src/main/java/com/jpp/mp/di/ViewModelModule.kt
+++ b/app/src/main/java/com/jpp/mp/di/ViewModelModule.kt
@@ -13,7 +13,6 @@ import com.jpp.mpaccount.account.lists.UserMovieListViewModel
 import com.jpp.mpaccount.login.LoginViewModel
 import com.jpp.mpcredits.CreditsViewModel
 import com.jpp.mpmoviedetails.MovieDetailsActionViewModel
-import com.jpp.mpmoviedetails.MovieDetailsViewModel
 import com.jpp.mpmoviedetails.rates.RateMovieViewModel
 import com.jpp.mpperson.PersonViewModel
 import com.jpp.mpsearch.SearchViewModel
@@ -64,10 +63,6 @@ abstract class ViewModelModule {
     /*
      * Movie details feature dependencies.
      */
-    @Binds
-    @IntoMap
-    @ViewModelKey(MovieDetailsViewModel::class)
-    internal abstract fun getMovieDetailsViewModel(viewModel: MovieDetailsViewModel): ViewModel
 
     @Binds
     @IntoMap

--- a/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsParam.kt
+++ b/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsParam.kt
@@ -1,10 +1,14 @@
 package com.jpp.mpmoviedetails
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
 /**
  * The initialization parameter for the [MovieDetailsViewModel.onInit] method.
  */
+@Parcelize
 internal data class MovieDetailsParam(
     val movieId: Double,
     val movieTitle: String,
     val movieImageUrl: String
-)
+) : Parcelable

--- a/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsViewModel.kt
+++ b/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsViewModel.kt
@@ -30,7 +30,6 @@ import com.jpp.mpdomain.usecase.Try
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
 /**
  * [MPViewModel] that supports the movie details section (only the static data, not the actions
@@ -43,7 +42,7 @@ import javax.inject.Inject
  * VM is notified about such event and executes a refresh of both: the data stored by the application
  * and the view state being shown to the user.
  */
-class MovieDetailsViewModel @Inject constructor(
+class MovieDetailsViewModel(
     private val getMovieDetailUseCase: GetMovieDetailUseCase,
     private val ioDispatcher: CoroutineDispatcher
 ) : MPViewModel() {

--- a/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsViewModelFactory.kt
+++ b/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsViewModelFactory.kt
@@ -1,0 +1,24 @@
+package com.jpp.mpmoviedetails
+
+import androidx.lifecycle.SavedStateHandle
+import com.jpp.mp.common.viewmodel.ViewModelAssistedFactory
+import com.jpp.mpdomain.usecase.GetMovieDetailUseCase
+import kotlinx.coroutines.CoroutineDispatcher
+import javax.inject.Inject
+
+/**
+ * [ViewModelAssistedFactory] to create specific [MovieDetailsViewModel] instances
+ * with the dependencies provided by Dagger.
+ */
+class MovieDetailsViewModelFactory @Inject constructor(
+    private val getMovieDetailUseCase: GetMovieDetailUseCase,
+    private val ioDispatcher: CoroutineDispatcher
+) : ViewModelAssistedFactory<MovieDetailsViewModel> {
+
+    override fun create(handle: SavedStateHandle): MovieDetailsViewModel {
+        return MovieDetailsViewModel(
+            getMovieDetailUseCase,
+            ioDispatcher
+        )
+    }
+}

--- a/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsViewModelFactory.kt
+++ b/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsViewModelFactory.kt
@@ -18,7 +18,8 @@ class MovieDetailsViewModelFactory @Inject constructor(
     override fun create(handle: SavedStateHandle): MovieDetailsViewModel {
         return MovieDetailsViewModel(
             getMovieDetailUseCase,
-            ioDispatcher
+            ioDispatcher,
+            handle
         )
     }
 }

--- a/features/mpmoviedetails/src/test/java/com/jpp/mpmoviedetails/MovieDetailsActionViewModelTest.kt
+++ b/features/mpmoviedetails/src/test/java/com/jpp/mpmoviedetails/MovieDetailsActionViewModelTest.kt
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource
         InstantTaskExecutorExtension::class,
         CoroutineTestExtension::class
 )
-class MovieDetailsActionViewModelTest {
+internal class MovieDetailsActionViewModelTest {
 
     @RelaxedMockK
     private lateinit var movieDetailsInteractor: MovieDetailsInteractor

--- a/features/mpmoviedetails/src/test/java/com/jpp/mpmoviedetails/MovieDetailsViewModelTest.kt
+++ b/features/mpmoviedetails/src/test/java/com/jpp/mpmoviedetails/MovieDetailsViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.jpp.mpmoviedetails
 
 import android.view.View
+import androidx.lifecycle.SavedStateHandle
 import com.jpp.mp.common.navigation.Destination
 import com.jpp.mpdomain.MovieDetail
 import com.jpp.mpdomain.MovieGenre
@@ -30,13 +31,18 @@ class MovieDetailsViewModelTest {
     @RelaxedMockK
     private lateinit var getMovieDetailUseCase: GetMovieDetailUseCase
 
+    private val savedStateHandle: SavedStateHandle by lazy {
+        SavedStateHandle()
+    }
+
     private lateinit var subject: MovieDetailsViewModel
 
     @BeforeEach
     fun setUp() {
         subject = MovieDetailsViewModel(
             getMovieDetailUseCase,
-            CoroutineTestExtension.testDispatcher
+            CoroutineTestExtension.testDispatcher,
+            savedStateHandle
         )
     }
 

--- a/features/mpmoviedetails/src/test/java/com/jpp/mpmoviedetails/rates/RateMovieViewModelTest.kt
+++ b/features/mpmoviedetails/src/test/java/com/jpp/mpmoviedetails/rates/RateMovieViewModelTest.kt
@@ -30,7 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource
         InstantTaskExecutorExtension::class,
         CoroutineTestExtension::class
 )
-class RateMovieViewModelTest {
+internal class RateMovieViewModelTest {
 
     @RelaxedMockK
     private lateinit var movieDetailsInteractor: MovieDetailsInteractor


### PR DESCRIPTION
This commit updates MovieDetailsViewModel to use
SavedStateHandle to recover when the system kills the 
application for some reason. The commit also contains
the factories needed to inject proper instances in the
MovieDetailsFragment.