### PR TITLE
Movie details feature updates creen title properly

### DIFF
--- a/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailViewState.kt
+++ b/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailViewState.kt
@@ -9,6 +9,7 @@ import com.jpp.mpdesign.views.MPErrorView.ErrorViewState
  */
 internal data class MovieDetailViewState(
     val loadingVisibility: Int = View.INVISIBLE,
+    val screenTitle: String,
     val movieImageUrl: String = "emptyUrl",
     val errorViewState: ErrorViewState = ErrorViewState.asNotVisible(),
     val contentViewState: MovieDetailContentViewState = MovieDetailContentViewState()
@@ -50,9 +51,9 @@ internal data class MovieDetailViewState(
     }
 
     companion object {
-        fun showLoading(movieImageUrl: String) = MovieDetailViewState(
-            loadingVisibility =
-            View.VISIBLE,
+        fun showLoading(screenTitle: String, movieImageUrl: String) = MovieDetailViewState(
+            loadingVisibility = View.VISIBLE,
+            screenTitle = screenTitle,
             movieImageUrl = movieImageUrl
         )
     }

--- a/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsFragment.kt
+++ b/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsFragment.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.jpp.mp.common.extensions.observeValue
+import com.jpp.mp.common.extensions.setScreenTitle
 import com.jpp.mp.common.extensions.withViewModel
 import com.jpp.mp.common.viewmodel.MPGenericSavedStateViewModelFactory
 import com.jpp.mpdesign.ext.setInvisible
@@ -132,6 +133,8 @@ class MovieDetailsFragment : Fragment() {
     }
 
     private fun renderViewState(viewState: MovieDetailViewState) {
+        setScreenTitle(viewState.screenTitle)
+
         viewBinding.viewState = viewState
         viewBinding.executePendingBindings()
 

--- a/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsViewModel.kt
+++ b/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsViewModel.kt
@@ -1,11 +1,7 @@
 package com.jpp.mpmoviedetails
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.*
 import com.jpp.mp.common.coroutines.MPViewModel
-import com.jpp.mp.common.navigation.Destination
 import com.jpp.mpdomain.MovieDetail
 import com.jpp.mpdomain.MovieGenre
 import com.jpp.mpdomain.MovieGenre.GenresId.ACTION_GENRE_ID
@@ -48,7 +44,7 @@ class MovieDetailsViewModel(
     private val navigator: MovieDetailsNavigator,
     private val ioDispatcher: CoroutineDispatcher,
     private val savedStateHandle: SavedStateHandle
-) : MPViewModel() {
+) : ViewModel() {
 
     private var movieId: Double
         set(value) {
@@ -92,8 +88,7 @@ class MovieDetailsViewModel(
         movieId = param.movieId
         movieTitle = param.movieTitle
         movieImageUrl = param.movieImageUrl
-        updateCurrentDestination(Destination.ReachedDestination(movieTitle))
-        fetchMovieDetails(movieId, movieImageUrl)
+        fetchMovieDetails()
     }
 
     /**
@@ -124,8 +119,8 @@ class MovieDetailsViewModel(
         )
     }
 
-    private fun fetchMovieDetails(movieId: Double, movieImageUrl: String) {
-        _viewState.value = MovieDetailViewState.showLoading(movieImageUrl)
+    private fun fetchMovieDetails() {
+        _viewState.value = MovieDetailViewState.showLoading(movieTitle, movieImageUrl)
         viewModelScope.launch {
             val result = withContext(ioDispatcher) {
                 getMovieDetailUseCase.execute(movieId)
@@ -140,16 +135,10 @@ class MovieDetailsViewModel(
     private fun processFailure(failure: Try.FailureCause) {
         _viewState.value = when (failure) {
             is Try.FailureCause.NoConnectivity -> _viewState.value?.showNoConnectivityError {
-                fetchMovieDetails(
-                    movieId,
-                    movieTitle
-                )
+                fetchMovieDetails()
             }
             is Try.FailureCause.Unknown -> _viewState.value?.showUnknownError {
-                fetchMovieDetails(
-                    movieId,
-                    movieTitle
-                )
+                fetchMovieDetails()
             }
         }
     }

--- a/features/mpmoviedetails/src/test/java/com/jpp/mpmoviedetails/MovieDetailsViewModelTest.kt
+++ b/features/mpmoviedetails/src/test/java/com/jpp/mpmoviedetails/MovieDetailsViewModelTest.kt
@@ -2,7 +2,6 @@ package com.jpp.mpmoviedetails
 
 import android.view.View
 import androidx.lifecycle.SavedStateHandle
-import com.jpp.mp.common.navigation.Destination
 import com.jpp.mpdomain.MovieDetail
 import com.jpp.mpdomain.MovieGenre
 import com.jpp.mpdomain.usecase.GetMovieDetailUseCase
@@ -105,7 +104,7 @@ class MovieDetailsViewModelTest {
             )
         )
 
-        val expected = MovieDetailViewState.showLoading("aUrl").showDetails(
+        val expected = MovieDetailViewState.showLoading("aTitle", "aUrl").showDetails(
             movieImageUrl = "aUrl",
             overview = domainDetail.overview,
             releaseDate = domainDetail.release_date,
@@ -120,21 +119,9 @@ class MovieDetailsViewModelTest {
         coEvery { getMovieDetailUseCase.execute(movieDetailId) } returns Try.Success(domainDetail)
 
         subject.viewState.observeWith { viewState -> viewStatePosted = viewState }
-        subject.onInit(MovieDetailsParam(movieDetailId, "aMovie", "aUrl"))
+        subject.onInit(MovieDetailsParam(movieDetailId, "aTitle", "aUrl"))
 
         assertEquals(expected, viewStatePosted)
-    }
-
-    @Test
-    fun `Should update reached destination in onInit`() {
-        var destinationReached: Destination? = null
-        val expected = Destination.ReachedDestination("aMovie")
-
-        subject.destinationEvents.observeWith { destinationReached = it }
-
-        subject.onInit(MovieDetailsParam(10.0, "aMovie", "aUrl"))
-
-        assertEquals(expected, destinationReached)
     }
 
     @Test


### PR DESCRIPTION
This commit removes the inheritance that `MovieDetailsViewModels`
has with `MPViewModel` as part of an ongoing refactor to remove such
inheritance. The title of the screen is now part of the view state
that the ViewModel creates and updates with each state change.