### PR TITLE
Use SavedStateHandle in CreditsViewModel

### DIFF
--- a/app/src/main/java/com/jpp/mp/di/ViewModelModule.kt
+++ b/app/src/main/java/com/jpp/mp/di/ViewModelModule.kt
@@ -11,7 +11,6 @@ import com.jpp.mpabout.licenses.content.LicenseContentViewModel
 import com.jpp.mpaccount.account.UserAccountViewModel
 import com.jpp.mpaccount.account.lists.UserMovieListViewModel
 import com.jpp.mpaccount.login.LoginViewModel
-import com.jpp.mpcredits.CreditsViewModel
 import com.jpp.mpperson.PersonViewModel
 import com.jpp.mpsearch.SearchViewModel
 import dagger.Binds
@@ -81,14 +80,6 @@ abstract class ViewModelModule {
     @IntoMap
     @ViewModelKey(PersonViewModel::class)
     internal abstract fun getPersonViewModel(viewModel: PersonViewModel): ViewModel
-
-    /*
-     * Credits feature dependencies
-     */
-    @Binds
-    @IntoMap
-    @ViewModelKey(CreditsViewModel::class)
-    internal abstract fun provideCreditsViewModel(viewModel: CreditsViewModel): ViewModel
 
     /*
      * About feature dependencies

--- a/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsAdapter.kt
+++ b/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsAdapter.kt
@@ -1,0 +1,42 @@
+package com.jpp.mpcredits
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.jpp.mpcredits.databinding.ListItemCreditsBinding
+
+/**
+ * [RecyclerView.Adapter] to render the credit list.
+ */
+internal class CreditsAdapter(
+    private val credits: List<CreditPerson>,
+    private val selectionListener: (CreditPerson) -> Unit
+) : RecyclerView.Adapter<CreditsAdapter.ViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        return ViewHolder(
+            DataBindingUtil.inflate(
+                LayoutInflater.from(parent.context),
+                R.layout.list_item_credits,
+                parent,
+                false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bindCredit(credits[position], selectionListener)
+    }
+
+    override fun getItemCount(): Int = credits.size
+
+    class ViewHolder(private val itemBinding: ListItemCreditsBinding) :
+        RecyclerView.ViewHolder(itemBinding.root) {
+        fun bindCredit(credit: CreditPerson, selectionListener: (CreditPerson) -> Unit) {
+            itemBinding.viewState = credit
+            itemBinding.executePendingBindings()
+            itemView.setOnClickListener { selectionListener(credit) }
+        }
+    }
+}

--- a/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsInitParam.kt
+++ b/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsInitParam.kt
@@ -1,26 +1,18 @@
 package com.jpp.mpcredits
 
-import com.jpp.mp.common.extensions.getResIdFromAttribute
-
 /**
  * The initialization parameter used for
  * CreditsViewModel initialization.
  */
 data class CreditsInitParam(
     val movieTitle: String,
-    val movieId: Double,
-    val targetImageSize: Int
+    val movieId: Double
 ) {
     companion object {
         fun create(fragment: CreditsFragment) =
             CreditsInitParam(
                 movieTitle = NavigationCredits.movieTitle(fragment.arguments),
-                movieId = NavigationCredits.movieId(fragment.arguments),
-                targetImageSize = fragment.resources.getDimensionPixelSize(
-                    fragment.getResIdFromAttribute(
-                        R.attr.mpCreditItemImageSize
-                    )
-                )
+                movieId = NavigationCredits.movieId(fragment.arguments)
             )
     }
 }

--- a/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsViewModel.kt
+++ b/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsViewModel.kt
@@ -14,7 +14,6 @@ import com.jpp.mpdomain.usecase.Try
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
 /**
  * [MPViewModel] that supports the credits section. The VM retrieves
@@ -26,13 +25,13 @@ import javax.inject.Inject
  * VM is notified about such event and executes a refresh of both: the data stored by the application
  * and the view state being shown to the user.
  */
-class CreditsViewModel @Inject constructor(
+class CreditsViewModel(
     private val getCreditsUseCase: GetCreditsUseCase,
     private val ioDispatcher: CoroutineDispatcher
 ) : MPViewModel() {
 
     private val _viewState = MediatorLiveData<CreditsViewState>()
-    val viewState: LiveData<CreditsViewState>  = _viewState
+    val viewState: LiveData<CreditsViewState> = _viewState
 
     private lateinit var currentParam: CreditsInitParam
 

--- a/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsViewModelFactory.kt
+++ b/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsViewModelFactory.kt
@@ -18,6 +18,6 @@ class CreditsViewModelFactory @Inject constructor(
 ) : ViewModelAssistedFactory<CreditsViewModel> {
 
     override fun create(handle: SavedStateHandle): CreditsViewModel {
-        return CreditsViewModel(getCreditsUseCase, ioDispatcher)
+        return CreditsViewModel(getCreditsUseCase, ioDispatcher, handle)
     }
 }

--- a/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsViewModelFactory.kt
+++ b/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsViewModelFactory.kt
@@ -1,0 +1,23 @@
+package com.jpp.mpcredits
+
+import androidx.lifecycle.SavedStateHandle
+import com.jpp.mp.common.viewmodel.ViewModelAssistedFactory
+import com.jpp.mpdomain.usecase.GetCreditsUseCase
+import kotlinx.coroutines.CoroutineDispatcher
+import javax.inject.Inject
+
+/**
+ * [ViewModelAssistedFactory] to create specific [CreditsViewModel] instances
+ * with the dependencies provided by Dagger.
+ * Note that Dagger inject's this object and this object takes care of creating
+ * the [CreditsViewModel] instance needed.
+ */
+class CreditsViewModelFactory @Inject constructor(
+    private val getCreditsUseCase: GetCreditsUseCase,
+    private val ioDispatcher: CoroutineDispatcher
+) : ViewModelAssistedFactory<CreditsViewModel> {
+
+    override fun create(handle: SavedStateHandle): CreditsViewModel {
+        return CreditsViewModel(getCreditsUseCase, ioDispatcher)
+    }
+}

--- a/features/mpcredits/src/test/java/com/jpp/mpcredits/CreditsViewModelTest.kt
+++ b/features/mpcredits/src/test/java/com/jpp/mpcredits/CreditsViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.jpp.mpcredits
 
 import android.view.View
+import androidx.lifecycle.SavedStateHandle
 import com.jpp.mp.common.navigation.Destination
 import com.jpp.mpdomain.CastCharacter
 import com.jpp.mpdomain.Credits
@@ -37,7 +38,8 @@ class CreditsViewModelTest {
     fun setUp() {
         subject = CreditsViewModel(
             getCreditsUseCase,
-            CoroutineTestExtension.testDispatcher
+            CoroutineTestExtension.testDispatcher,
+            SavedStateHandle()
         )
     }
 
@@ -48,7 +50,7 @@ class CreditsViewModelTest {
         coEvery { getCreditsUseCase.execute(any()) } returns Try.Failure(Try.FailureCause.NoConnectivity)
 
         subject.viewState.observeWith { viewState -> viewStatePosted = viewState }
-        subject.onInit(CreditsInitParam("aMovie", 10.0, 12))
+        subject.onInit(CreditsInitParam("aMovie", 10.0))
 
         assertNotNull(viewStatePosted)
         assertEquals(View.INVISIBLE, viewStatePosted?.loadingVisibility)
@@ -67,7 +69,7 @@ class CreditsViewModelTest {
 
         subject.viewState.observeWith { viewState -> viewStatePosted = viewState }
 
-        subject.onInit(CreditsInitParam("aMovie", 10.0, 12))
+        subject.onInit(CreditsInitParam("aMovie", 10.0))
 
         viewStatePosted?.let {
             it.errorViewState.errorHandler?.invoke()
@@ -82,7 +84,7 @@ class CreditsViewModelTest {
         coEvery { getCreditsUseCase.execute(any()) } returns Try.Failure(Try.FailureCause.Unknown)
 
         subject.viewState.observeWith { viewState -> viewStatePosted = viewState }
-        subject.onInit(CreditsInitParam("aMovie", 10.0, 12))
+        subject.onInit(CreditsInitParam("aMovie", 10.0))
 
         assertNotNull(viewStatePosted)
         assertEquals(View.INVISIBLE, viewStatePosted?.loadingVisibility)
@@ -100,7 +102,7 @@ class CreditsViewModelTest {
         coEvery { getCreditsUseCase.execute(any()) } returns Try.Failure(Try.FailureCause.NoConnectivity)
 
         subject.viewState.observeWith { viewState -> viewStatePosted = viewState }
-        subject.onInit(CreditsInitParam("aMovie", 10.0, 12))
+        subject.onInit(CreditsInitParam("aMovie", 10.0))
 
         viewStatePosted?.let {
             it.errorViewState.errorHandler?.invoke()
@@ -121,7 +123,7 @@ class CreditsViewModelTest {
         coEvery { getCreditsUseCase.execute(any()) } returns Try.Success(credits)
 
         subject.viewState.observeWith { viewState -> viewStatePosted = viewState }
-        subject.onInit(CreditsInitParam("aMovie", 10.0, 12))
+        subject.onInit(CreditsInitParam("aMovie", 10.0))
 
         assertNotNull(viewStatePosted)
         assertEquals(View.INVISIBLE, viewStatePosted?.loadingVisibility)
@@ -149,7 +151,7 @@ class CreditsViewModelTest {
 
         subject.viewState.observeWith { viewState -> viewStatePosted = viewState }
 
-        subject.onInit(CreditsInitParam("aMovie", 10.0, 12))
+        subject.onInit(CreditsInitParam("aMovie", 10.0))
 
         assertNotNull(viewStatePosted)
         assertEquals(View.INVISIBLE, viewStatePosted?.loadingVisibility)
@@ -184,7 +186,7 @@ class CreditsViewModelTest {
 
         subject.destinationEvents.observeWith { destinationReached = it }
 
-        subject.onInit(CreditsInitParam("aMovie", 10.0, 12))
+        subject.onInit(CreditsInitParam("aMovie", 10.0))
 
         assertEquals(expected, destinationReached)
     }


### PR DESCRIPTION
This commit updates `CreditsViewModel` to use a `SavedStateHandle`
to store/recreate state when the app is killed by the system. It also updates
the Dagger implementation to create and inject the dependencies needed.
As a plus, this commits moves `CreditsAdapter ` to its own file to do some
house-keeping.