### PR TITLE
Refactor credits navigation

### DIFF
--- a/app/src/main/java/com/jpp/mp/di/NavigationModule.kt
+++ b/app/src/main/java/com/jpp/mp/di/NavigationModule.kt
@@ -2,6 +2,7 @@ package com.jpp.mp.di
 
 import com.jpp.mp.main.MainNavigator
 import com.jpp.mp.main.movies.MovieListNavigator
+import com.jpp.mpcredits.CreditNavigator
 import com.jpp.mpmoviedetails.MovieDetailsNavigator
 import com.jpp.mpmoviedetails.rates.RateMovieNavigator
 import dagger.Module
@@ -26,4 +27,7 @@ class NavigationModule {
 
     @Provides
     fun providesRateMovieNavigator(mainNavigator: MainNavigator): RateMovieNavigator = mainNavigator
+
+    @Provides
+    fun providesCreditNavigator(mainNavigator: MainNavigator): CreditNavigator = mainNavigator
 }

--- a/app/src/main/java/com/jpp/mp/main/MainNavigator.kt
+++ b/app/src/main/java/com/jpp/mp/main/MainNavigator.kt
@@ -6,17 +6,22 @@ import androidx.navigation.NavDirections
 import androidx.navigation.NavOptions
 import com.jpp.mp.R
 import com.jpp.mp.main.movies.MovieListNavigator
+import com.jpp.mpcredits.CreditNavigator
 import com.jpp.mpcredits.NavigationCredits
 import com.jpp.mpmoviedetails.MovieDetailsFragmentDirections
 import com.jpp.mpmoviedetails.MovieDetailsNavigator
 import com.jpp.mpmoviedetails.NavigationMovieDetails
 import com.jpp.mpmoviedetails.rates.RateMovieNavigator
+import com.jpp.mpperson.NavigationPerson
 
 /**
  * Provides navigation to the main module and also to each individual
  * feature module.
  */
-class MainNavigator : MovieListNavigator, MovieDetailsNavigator, RateMovieNavigator {
+class MainNavigator : MovieListNavigator,
+    MovieDetailsNavigator,
+    RateMovieNavigator,
+    CreditNavigator {
 
     private var navController: NavController? = null
 
@@ -81,6 +86,22 @@ class MainNavigator : MovieListNavigator, MovieDetailsNavigator, RateMovieNaviga
                 movieImageUrl,
                 movieTitle
             )
+        )
+    }
+
+    override fun navigateToCreditDetail(
+        personId: String,
+        personImageUrl: String,
+        personName: String
+    ) {
+        navController?.navigate(
+            R.id.person_nav,
+            NavigationPerson.navArgs(
+                personId,
+                personImageUrl,
+                personName
+            ),
+            buildAnimationNavOptions()
         )
     }
 

--- a/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditNavigator.kt
+++ b/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditNavigator.kt
@@ -1,0 +1,13 @@
+package com.jpp.mpcredits
+
+/**
+ * Provides navigation for the credits module.
+ */
+interface CreditNavigator {
+
+    fun navigateToCreditDetail(
+        personId: String,
+        personImageUrl: String,
+        personName: String
+    )
+}

--- a/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsFragment.kt
+++ b/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsFragment.kt
@@ -9,13 +9,13 @@ import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.jpp.mp.common.extensions.observeValue
+import com.jpp.mp.common.extensions.setScreenTitle
 import com.jpp.mp.common.viewmodel.MPGenericSavedStateViewModelFactory
 import com.jpp.mpcredits.databinding.CreditsFragmentBinding
-import com.jpp.mpcredits.databinding.ListItemCreditsBinding
 import dagger.android.support.AndroidSupportInjection
 import javax.inject.Inject
 
@@ -71,13 +71,7 @@ class CreditsFragment : Fragment() {
 
         rvState = savedInstanceState?.getParcelable(CREDITS_RV_STATE_KEY) ?: rvState
 
-        viewModel.viewState.observe(viewLifecycleOwner, Observer { viewState ->
-            movieCreditsRv?.adapter = CreditsAdapter(viewState.creditsViewState.creditItems) {
-                viewModel.onCreditItemSelected(it)
-            }
-            viewBinding.viewState = viewState
-            viewBinding.executePendingBindings()
-        })
+        viewModel.viewState.observeValue(viewLifecycleOwner, ::renderViewState)
         viewModel.onInit(CreditsInitParam.create(this@CreditsFragment))
     }
 
@@ -107,6 +101,15 @@ class CreditsFragment : Fragment() {
                 DividerItemDecoration(context, (layoutManager as LinearLayoutManager).orientation)
             )
         }
+    }
+
+    private fun renderViewState(viewState: CreditsViewState) {
+        setScreenTitle(viewState.screenTitle)
+        movieCreditsRv?.adapter = CreditsAdapter(viewState.creditsViewState.creditItems) {
+            viewModel.onCreditItemSelected(it)
+        }
+        viewBinding.viewState = viewState
+        viewBinding.executePendingBindings()
     }
 
     private companion object {

--- a/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsViewModel.kt
+++ b/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsViewModel.kt
@@ -1,12 +1,7 @@
 package com.jpp.mpcredits
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MediatorLiveData
-import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.viewModelScope
-import com.jpp.mp.common.coroutines.MPViewModel
+import androidx.lifecycle.*
 import com.jpp.mp.common.extensions.addAllMapping
-import com.jpp.mp.common.navigation.Destination
 import com.jpp.mpdomain.CastCharacter
 import com.jpp.mpdomain.Credits
 import com.jpp.mpdomain.CrewMember
@@ -17,7 +12,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
- * [MPViewModel] that supports the credits section. The VM retrieves
+ * [ViewModel] that supports the credits section. The VM retrieves
  * the data from the underlying layers and maps the business
  * data to UI data, producing a [CreditsViewState] that represents the configuration of the view
  * at any given moment.
@@ -28,9 +23,10 @@ import kotlinx.coroutines.withContext
  */
 class CreditsViewModel(
     private val getCreditsUseCase: GetCreditsUseCase,
+    private val navigator: CreditNavigator,
     private val ioDispatcher: CoroutineDispatcher,
     private val savedStateHandle: SavedStateHandle
-) : MPViewModel() {
+) : ViewModel() {
 
     private val _viewState = MediatorLiveData<CreditsViewState>()
     val viewState: LiveData<CreditsViewState> = _viewState
@@ -69,15 +65,11 @@ class CreditsViewModel(
      * Called when an item is selected in the list of credit persons.
      */
     fun onCreditItemSelected(personItem: CreditPerson) {
-        with(personItem) {
-            navigateTo(
-                Destination.MPPerson(
-                    personId = id.toString(),
-                    personImageUrl = profilePath,
-                    personName = subTitle
-                )
-            )
-        }
+        navigator.navigateToCreditDetail(
+            personItem.id.toString(),
+            personItem.profilePath,
+            personItem.subTitle
+        )
     }
 
     /**

--- a/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsViewModel.kt
+++ b/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsViewModel.kt
@@ -44,6 +44,15 @@ class CreditsViewModel(
                 ?: throw IllegalStateException("Trying to access MOVIE_ID_KEY when it is not yet set")
         }
 
+    private var movieTitle: String
+        set(value) {
+            savedStateHandle.set(MOVIE_TITLE_KEY, value)
+        }
+        get() {
+            return savedStateHandle.get(MOVIE_TITLE_KEY)
+                ?: throw IllegalStateException("Trying to access MOVIE_TITLE_KEY when it is not yet set")
+        }
+
     /**
      * Called on VM initialization. The View (Fragment) should call this method to
      * indicate that it is ready to start rendering. When the method is called, the VM
@@ -52,7 +61,7 @@ class CreditsViewModel(
      */
     fun onInit(param: CreditsInitParam) {
         movieId = param.movieId
-        updateCurrentDestination(Destination.ReachedDestination(param.movieTitle))
+        movieTitle = param.movieTitle
         fetchMovieCredits()
     }
 
@@ -76,7 +85,7 @@ class CreditsViewModel(
      * of the movie being shown.
      */
     private fun fetchMovieCredits() {
-        _viewState.value = CreditsViewState.showLoading()
+        _viewState.value = CreditsViewState.showLoading(movieTitle)
         viewModelScope.launch {
             val result = withContext(ioDispatcher) {
                 getCreditsUseCase.execute(movieId)
@@ -130,5 +139,6 @@ class CreditsViewModel(
 
     private companion object {
         const val MOVIE_ID_KEY = "MOVIE_ID_KEY"
+        const val MOVIE_TITLE_KEY = "MOVIE_TITLE_KEY"
     }
 }

--- a/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsViewModelFactory.kt
+++ b/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsViewModelFactory.kt
@@ -14,10 +14,11 @@ import javax.inject.Inject
  */
 class CreditsViewModelFactory @Inject constructor(
     private val getCreditsUseCase: GetCreditsUseCase,
+    private val creditNavigator: CreditNavigator,
     private val ioDispatcher: CoroutineDispatcher
 ) : ViewModelAssistedFactory<CreditsViewModel> {
 
     override fun create(handle: SavedStateHandle): CreditsViewModel {
-        return CreditsViewModel(getCreditsUseCase, ioDispatcher, handle)
+        return CreditsViewModel(getCreditsUseCase, creditNavigator, ioDispatcher, handle)
     }
 }

--- a/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsViewState.kt
+++ b/features/mpcredits/src/main/java/com/jpp/mpcredits/CreditsViewState.kt
@@ -8,6 +8,7 @@ import com.jpp.mpdesign.views.MPErrorView.ErrorViewState
  */
 data class CreditsViewState(
     val loadingVisibility: Int = View.INVISIBLE,
+    val screenTitle: String,
     val errorViewState: ErrorViewState = ErrorViewState.asNotVisible(),
     val creditsViewState: CreditsContentViewState = CreditsContentViewState(),
     val noCreditsViewState: NoCreditsAvailableViewState = NoCreditsAvailableViewState()
@@ -38,6 +39,7 @@ data class CreditsViewState(
         )
 
     companion object {
-        fun showLoading() = CreditsViewState(loadingVisibility = View.VISIBLE)
+        fun showLoading(screenTitle: String) =
+            CreditsViewState(loadingVisibility = View.VISIBLE, screenTitle = screenTitle)
     }
 }


### PR DESCRIPTION
This commit refactors the navigation implementation
in the credits section to perform the navigation in a clean
way by using an interface that is injected into the `CreditsViewModel`