### PR TITLE
Introduce transitions to go to search

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/app/src/main/java/com/jpp/mp/main/MainActivity.kt
+++ b/app/src/main/java/com/jpp/mp/main/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.jpp.mp.main
 
+import android.app.ActivityOptions
+import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
@@ -18,6 +20,7 @@ import com.jpp.mp.R
 import com.jpp.mp.common.extensions.withViewModel
 import com.jpp.mp.common.navigation.NavigationViewModel
 import com.jpp.mpdesign.ext.closeDrawerIfOpen
+import com.jpp.mpsearch.SearchActivity
 import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
@@ -63,6 +66,10 @@ class MainActivity : AppCompatActivity(), HasSupportFragmentInjector {
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        // Important to avoid blinks in transitions.
+        // Source -> https://stackoverflow.com/questions/28364106/blinking-screen-on-image-transition-between-activities
+        window.exitTransition = null
 
         mainToolbar = findViewById(R.id.mainToolbar)
 
@@ -217,5 +224,13 @@ class MainActivity : AppCompatActivity(), HasSupportFragmentInjector {
          */
         invalidateOptionsMenu()
         mainDrawerLayout.closeDrawerIfOpen()
+    }
+
+    fun navigateToSearch() {
+        val intent = Intent(this, SearchActivity::class.java)
+        val transitionOptions = ActivityOptions.makeSceneTransitionAnimation(
+            this, mainToolbar, getString(R.string.toolbar_search_transition)
+        ).toBundle()
+        startActivity(intent, transitionOptions)
     }
 }

--- a/app/src/main/java/com/jpp/mp/main/MainActivity.kt
+++ b/app/src/main/java/com/jpp/mp/main/MainActivity.kt
@@ -1,7 +1,5 @@
 package com.jpp.mp.main
 
-import android.app.ActivityOptions
-import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
@@ -20,7 +18,6 @@ import com.jpp.mp.R
 import com.jpp.mp.common.extensions.withViewModel
 import com.jpp.mp.common.navigation.NavigationViewModel
 import com.jpp.mpdesign.ext.closeDrawerIfOpen
-import com.jpp.mpsearch.SearchActivity
 import dagger.android.AndroidInjection
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
@@ -131,6 +128,7 @@ class MainActivity : AppCompatActivity(), HasSupportFragmentInjector {
     override fun onResume() {
         super.onResume()
         mainNavigator.bind(findNavController(R.id.mainNavHostFragment))
+        mainNavigator.bindDelegate(MainToSearchNavigationDelegate(this, mainToolbar))
     }
 
     override fun onPause() {
@@ -224,13 +222,5 @@ class MainActivity : AppCompatActivity(), HasSupportFragmentInjector {
          */
         invalidateOptionsMenu()
         mainDrawerLayout.closeDrawerIfOpen()
-    }
-
-    fun navigateToSearch() {
-        val intent = Intent(this, SearchActivity::class.java)
-        val transitionOptions = ActivityOptions.makeSceneTransitionAnimation(
-            this, mainToolbar, getString(R.string.toolbar_search_transition)
-        ).toBundle()
-        startActivity(intent, transitionOptions)
     }
 }

--- a/app/src/main/java/com/jpp/mp/main/MainNavigator.kt
+++ b/app/src/main/java/com/jpp/mp/main/MainNavigator.kt
@@ -24,6 +24,7 @@ class MainNavigator : MovieListNavigator,
     SearchNavigator {
 
     private var navController: NavController? = null
+    private var mainToSearchDelegate: MainToSearchNavigationDelegate? = null
 
     override fun navigateToMovieDetails(
         movieId: String,
@@ -43,11 +44,14 @@ class MainNavigator : MovieListNavigator,
     }
 
     override fun navigateToSearch() {
-        navController?.navigate(
-            R.id.searchActivity,
-            null,
-            buildAnimationNavOptions()
-        )
+        val handled = mainToSearchDelegate?.onNavigateToSearch() ?: false
+        if (!handled) {
+            navController?.navigate(
+                R.id.searchActivity,
+                null,
+                buildAnimationNavOptions()
+            )
+        }
     }
 
     override fun navigateToAboutSection() {
@@ -127,8 +131,14 @@ class MainNavigator : MovieListNavigator,
         navController = newNavController
     }
 
+    internal fun bindDelegate(navigator: MainToSearchNavigationDelegate) {
+        mainToSearchDelegate = navigator
+    }
+
     override fun unBind() {
         navController = null
+        mainToSearchDelegate?.onDestroy()
+        mainToSearchDelegate = null
     }
 
     private fun buildAnimationNavOptions() = NavOptions.Builder()

--- a/app/src/main/java/com/jpp/mp/main/MainToSearchNavigationDelegate.kt
+++ b/app/src/main/java/com/jpp/mp/main/MainToSearchNavigationDelegate.kt
@@ -1,0 +1,41 @@
+package com.jpp.mp.main
+
+import android.app.ActivityOptions
+import android.content.Intent
+import androidx.appcompat.widget.Toolbar
+import com.jpp.mp.R
+import com.jpp.mpsearch.SearchActivity
+
+/**
+ * Delegate to perform the navigation from [MainActivity] to [SearchActivity].
+ * The navigation between these two Activities involves a shared element transition
+ * that, at the moment of the creation of this delegate, could not be implemented
+ * with the Android Navigation Components. Therefore, this delegate has the responsibility
+ * of performing the navigation by adding an extra configuration to perform the
+ * shared element transitions.
+ */
+internal class MainToSearchNavigationDelegate(
+    private var activity: MainActivity?,
+    private var transitionToolbar: Toolbar?
+) {
+
+    fun onNavigateToSearch(): Boolean {
+        val hostActivity = activity ?: return false
+        val transitionView = transitionToolbar ?: return false
+
+        val intent = Intent(hostActivity, SearchActivity::class.java)
+        val transitionOptions = ActivityOptions.makeSceneTransitionAnimation(
+            hostActivity,
+            transitionView,
+            hostActivity.getString(R.string.toolbar_search_transition)
+        ).toBundle()
+        hostActivity.startActivity(intent, transitionOptions)
+
+        return true
+    }
+
+    fun onDestroy() {
+        activity = null
+        transitionToolbar = null
+    }
+}

--- a/app/src/main/java/com/jpp/mp/main/movies/MovieListFragment.kt
+++ b/app/src/main/java/com/jpp/mp/main/movies/MovieListFragment.kt
@@ -15,6 +15,7 @@ import com.jpp.mp.common.extensions.setScreenTitle
 import com.jpp.mp.common.paging.MPVerticalPagingHandler
 import com.jpp.mp.databinding.FragmentMovieListBinding
 import com.jpp.mp.common.viewmodel.MPGenericSavedStateViewModelFactory
+import com.jpp.mp.main.MainActivity
 import com.jpp.mpdomain.MovieSection
 import dagger.android.support.AndroidSupportInjection
 import javax.inject.Inject
@@ -122,7 +123,8 @@ abstract class MovieListFragment : Fragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.search_menu -> {
-                viewModel.onSearchOptionSelected()
+//                viewModel.onSearchOptionSelected()
+                navigateToSearch()
                 return true
             }
             R.id.about_menu -> {
@@ -154,5 +156,9 @@ abstract class MovieListFragment : Fragment() {
 
     private companion object {
         const val MOVIES_RV_STATE_KEY = "moviesRvStateKey"
+    }
+
+    private fun navigateToSearch() {
+        (requireActivity() as MainActivity).navigateToSearch()
     }
 }

--- a/app/src/main/java/com/jpp/mp/main/movies/MovieListFragment.kt
+++ b/app/src/main/java/com/jpp/mp/main/movies/MovieListFragment.kt
@@ -123,8 +123,7 @@ abstract class MovieListFragment : Fragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.search_menu -> {
-//                viewModel.onSearchOptionSelected()
-                navigateToSearch()
+                viewModel.onSearchOptionSelected()
                 return true
             }
             R.id.about_menu -> {
@@ -156,9 +155,5 @@ abstract class MovieListFragment : Fragment() {
 
     private companion object {
         const val MOVIES_RV_STATE_KEY = "moviesRvStateKey"
-    }
-
-    private fun navigateToSearch() {
-        (requireActivity() as MainActivity).navigateToSearch()
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -15,6 +15,8 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/mpActionBarHeightNormal"
             android:transitionName="@string/toolbar_search_transition"
+            app:contentInsetStart="0dp"
+            app:contentInsetStartWithNavigation="0dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,6 +14,7 @@
             android:id="@+id/mainToolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/mpActionBarHeightNormal"
+            android:transitionName="@string/toolbar_search_transition"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/features/mpsearch/src/main/java/com/jpp/mpsearch/SearchActivity.kt
+++ b/features/mpsearch/src/main/java/com/jpp/mpsearch/SearchActivity.kt
@@ -1,6 +1,7 @@
 package com.jpp.mpsearch
 
 import android.os.Bundle
+import android.transition.Fade
 import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -55,9 +56,8 @@ class SearchActivity : AppCompatActivity(), HasSupportFragmentInjector {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.search_activity)
 
-        // Important to avoid blinks in transitions.
-        // Source -> https://stackoverflow.com/questions/28364106/blinking-screen-on-image-transition-between-activities
-        window.enterTransition = null
+        window.enterTransition = Fade(Fade.IN)
+        window.returnTransition = Fade(Fade.OUT)
 
         setupViews()
         setupNavigation()

--- a/features/mpsearch/src/main/java/com/jpp/mpsearch/SearchActivity.kt
+++ b/features/mpsearch/src/main/java/com/jpp/mpsearch/SearchActivity.kt
@@ -55,6 +55,10 @@ class SearchActivity : AppCompatActivity(), HasSupportFragmentInjector {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.search_activity)
 
+        // Important to avoid blinks in transitions.
+        // Source -> https://stackoverflow.com/questions/28364106/blinking-screen-on-image-transition-between-activities
+        window.enterTransition = null
+
         setupViews()
         setupNavigation()
 

--- a/features/mpsearch/src/main/res/layout/search_activity.xml
+++ b/features/mpsearch/src/main/res/layout/search_activity.xml
@@ -7,8 +7,9 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/searchToolBar"
         android:layout_width="match_parent"
-        android:layout_height="?attr/mpActionBarHeightNormal"
+        android:layout_height="60dp"
         app:contentInsetStart="0dp"
+        android:transitionName="@string/toolbar_search_transition"
         app:contentInsetStartWithNavigation="0dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/features/mpsearch/src/main/res/layout/search_activity.xml
+++ b/features/mpsearch/src/main/res/layout/search_activity.xml
@@ -7,7 +7,7 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/searchToolBar"
         android:layout_width="match_parent"
-        android:layout_height="60dp"
+        android:layout_height="?attr/mpActionBarHeightExpanded"
         app:contentInsetStart="0dp"
         android:transitionName="@string/toolbar_search_transition"
         app:contentInsetStartWithNavigation="0dp"

--- a/features/mpsearch/src/main/res/values/strings.xml
+++ b/features/mpsearch/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <resources>
     <string name="search_hint">Search movies and characters</string>
     <string name="empty_search">No results found for your search</string>
+
+    <string name="toolbar_search_transition" translatable="false">SearchToolbarTransition</string>
 </resources>

--- a/mpdesign/src/main/res/values/dimens.xml
+++ b/mpdesign/src/main/res/values/dimens.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="action_bar_height_expanded">340dp</dimen>
+    <dimen name="action_bar_height_expanded">60dp</dimen>
     <dimen name="action_bar_height_normal">48dp</dimen>
     <dimen name="mp_loading_view_stroke_width">3dp</dimen>
     <dimen name="title_text_size">18sp</dimen>

--- a/mpdesign/src/main/res/values/styles.xml
+++ b/mpdesign/src/main/res/values/styles.xml
@@ -9,6 +9,9 @@
 
         <item name="android:windowBackground">@color/windowBackground</item>
 
+        <!-- This is important for the transitions executed between activities-->
+        <item name="android:windowSharedElementsUseOverlay">false</item>
+
         <item name="mpActionBarHeightExpanded">@dimen/action_bar_height_expanded</item>
         <item name="mpActionBarHeightNormal">@dimen/action_bar_height_normal</item>
 


### PR DESCRIPTION
This commit adds the logic to perform a shared element transition
between `MainActivity` and `SearchActivity`.
I've tried to implement this using the Android Navigation Component
that comes in Android Jetpack but I've found an issue: when navigating
back there's a weird blink that I couldn't get rid of. That's why I decided
to implement this without the Navigation Component and that's where 
`MainToSearchNavigationDelegate` comes in.