### PR TITLE
Update AboutViewModel to remove AboutInteractor

### DIFF
--- a/features/mpabout/src/main/java/com/jpp/mpabout/AboutFragment.kt
+++ b/features/mpabout/src/main/java/com/jpp/mpabout/AboutFragment.kt
@@ -52,7 +52,7 @@ class AboutFragment : MPFragment<AboutViewModel>() {
 
             navEvents.observe(viewLifecycleOwner, Observer { it.actionIfNotHandled { navEvent -> processNavEvent(navEvent) } })
 
-            onInit(getString(R.string.about_top_bar_title))
+            onInit()
         }
     }
 

--- a/features/mpabout/src/main/java/com/jpp/mpabout/AboutViewModel.kt
+++ b/features/mpabout/src/main/java/com/jpp/mpabout/AboutViewModel.kt
@@ -17,7 +17,7 @@ import javax.inject.Inject
  * the data from the underlying layers using the provided [AboutInteractor] and maps the business
  * data to UI data, producing a [AboutViewState] that represents the configuration of the view.
  */
-class A @Inject constructor(
+class AboutViewModel @Inject constructor(
     private val appVersionRepository: AppVersionRepository,
     private val aboutUrlRepository: AboutUrlRepository
 ) : MPViewModel() {

--- a/features/mpabout/src/main/java/com/jpp/mpabout/AboutViewModel.kt
+++ b/features/mpabout/src/main/java/com/jpp/mpabout/AboutViewModel.kt
@@ -3,59 +3,40 @@ package com.jpp.mpabout
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.viewModelScope
 import com.jpp.mp.common.coroutines.MPViewModel
 import com.jpp.mp.common.livedata.HandledEvent
 import com.jpp.mp.common.livedata.HandledEvent.Companion.of
 import com.jpp.mp.common.navigation.Destination
-import com.jpp.mpabout.AboutInteractor.AboutEvent.AboutUrlEvent
-import com.jpp.mpabout.AboutInteractor.AboutEvent.AboutWebStoreUrlEvent
-import com.jpp.mpabout.AboutInteractor.AboutEvent.AppVersionEvent
 import com.jpp.mpdomain.AboutUrl
+import com.jpp.mpdomain.repository.AboutUrlRepository
+import com.jpp.mpdomain.repository.AppVersionRepository
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * [MPViewModel] that supports the about section. The VM retrieves
  * the data from the underlying layers using the provided [AboutInteractor] and maps the business
  * data to UI data, producing a [AboutViewState] that represents the configuration of the view.
  */
-class AboutViewModel @Inject constructor(
-    private val aboutInteractor: AboutInteractor
+class A @Inject constructor(
+    private val appVersionRepository: AppVersionRepository,
+    private val aboutUrlRepository: AboutUrlRepository
 ) : MPViewModel() {
 
     private val _viewState = MediatorLiveData<AboutViewState>()
-    val viewState: LiveData<AboutViewState> get() = _viewState
+    val viewState: LiveData<AboutViewState> = _viewState
 
     private val _navEvents = MutableLiveData<HandledEvent<AboutNavEvent>>()
-    val navEvents: LiveData<HandledEvent<AboutNavEvent>> get() = _navEvents
+    val navEvents: LiveData<HandledEvent<AboutNavEvent>> = _navEvents
 
     private lateinit var selectedItem: AboutItem
     private val supportedAboutItems = listOf(
-            AboutItem.RateApp,
-            AboutItem.ShareApp,
-            AboutItem.PrivacyPolicy,
-            AboutItem.BrowseAppCode,
-            AboutItem.Licenses,
-            AboutItem.TheMovieDbTermsOfUse
+        AboutItem.RateApp,
+        AboutItem.ShareApp,
+        AboutItem.PrivacyPolicy,
+        AboutItem.BrowseAppCode,
+        AboutItem.Licenses,
+        AboutItem.TheMovieDbTermsOfUse
     )
-
-    /*
-     * Map the business logic coming from the interactor into view layer logic.
-     */
-    init {
-        _viewState.addSource(aboutInteractor.events) { event ->
-            when (event) {
-                is AppVersionEvent -> _viewState.value = AboutViewState.showContent(
-                        appVersion = "v ${event.appVersion.version}",
-                        aboutItems = supportedAboutItems)
-                is AboutUrlEvent -> processAboutUrl(event.aboutUrl)
-                is AboutWebStoreUrlEvent -> _navEvents.value = of(AboutNavEvent.InnerNavigation(event.aboutUrl.url))
-            }
-        }
-    }
 
     /**
      * Called on VM initialization. The View (Fragment) should call this method to
@@ -63,10 +44,11 @@ class AboutViewModel @Inject constructor(
      * internally verifies the state of the application and updates the view state based
      * on it.
      */
-    fun onInit(screenTitle: String) {
-        updateCurrentDestination(Destination.ReachedDestination(screenTitle))
-        _viewState.value = AboutViewState.showLoading()
-        withInteractor { fetchAppVersion() }
+    fun onInit() {
+        _viewState.value = AboutViewState.showContent(
+            appVersion = "v ${appVersionRepository.getCurrentAppVersion().version}",
+            aboutItems = supportedAboutItems
+        )
     }
 
     /**
@@ -75,11 +57,11 @@ class AboutViewModel @Inject constructor(
     fun onUserSelectedAboutItem(aboutItem: AboutItem) {
         selectedItem = aboutItem
         when (aboutItem) {
-            is AboutItem.BrowseAppCode -> withInteractor { getRepoUrl() }
-            is AboutItem.TheMovieDbTermsOfUse -> withInteractor { getApiTermOfUseUrl() }
-            is AboutItem.PrivacyPolicy -> withInteractor { getPrivacyPolicyUrl() }
-            is AboutItem.RateApp -> withInteractor { getStoreUrl() }
-            is AboutItem.ShareApp -> withInteractor { getShareUrl() }
+            is AboutItem.BrowseAppCode -> processAboutUrl(aboutUrlRepository.getCodeRepoUrl())
+            is AboutItem.TheMovieDbTermsOfUse -> processAboutUrl(aboutUrlRepository.getTheMovieDbTermOfUseUrl())
+            is AboutItem.PrivacyPolicy -> processAboutUrl(aboutUrlRepository.getPrivacyPolicyUrl())
+            is AboutItem.RateApp -> processAboutUrl(aboutUrlRepository.getGPlayAppUrl())
+            is AboutItem.ShareApp -> processAboutUrl(aboutUrlRepository.getSharingUrl())
             is AboutItem.Licenses -> navigateTo(Destination.InnerDestination(AboutFragmentDirections.licensesFragment()))
         }
     }
@@ -88,15 +70,7 @@ class AboutViewModel @Inject constructor(
      * Called when the app fails to expanded the Google Play app in the device.
      */
     fun onFailedToOpenPlayStore() {
-        withInteractor { getWebStoreUrl() }
-    }
-
-    private fun withInteractor(action: AboutInteractor.() -> Unit) {
-        viewModelScope.launch {
-            withContext(Dispatchers.IO) {
-                action(aboutInteractor)
-            }
-        }
+        processAboutUrl(aboutUrlRepository.getGPlayWebUrl())
     }
 
     private fun processAboutUrl(aboutUrl: AboutUrl) {

--- a/features/mpabout/src/main/java/com/jpp/mpabout/about_ui_model.kt
+++ b/features/mpabout/src/main/java/com/jpp/mpabout/about_ui_model.kt
@@ -16,13 +16,13 @@ import androidx.annotation.StringRes
  * Represents the view state of the about fragment.
  */
 data class AboutViewState(
+    val screenTitle: Int = R.string.about_top_bar_title,
     val loadingVisibility: Int = View.INVISIBLE,
     val header: AboutHeader = AboutHeader(),
     val content: AboutContent = AboutContent()
 ) {
 
     companion object {
-        fun showLoading() = AboutViewState()
         fun showContent(
             appVersion: String,
             aboutItems: List<AboutItem>


### PR DESCRIPTION
This commit updates `AboutViewModel` to replace the usage of
`AboutInteractor`. Since the use cases this view model supports
are extremely simple, I decided to avoid the introduction of a UseCase
and let the ViewModel query the Repository layer directly.