### PR TITLE
Remove MPFragment and MPViewModel from Login

### DIFF
--- a/app/src/main/java/com/jpp/mp/di/NavigationModule.kt
+++ b/app/src/main/java/com/jpp/mp/di/NavigationModule.kt
@@ -3,6 +3,7 @@ package com.jpp.mp.di
 import com.jpp.mp.main.MainNavigator
 import com.jpp.mp.main.movies.MovieListNavigator
 import com.jpp.mpabout.AboutNavigator
+import com.jpp.mpaccount.login.LoginNavigator
 import com.jpp.mpcredits.CreditNavigator
 import com.jpp.mpmoviedetails.MovieDetailsNavigator
 import com.jpp.mpmoviedetails.rates.RateMovieNavigator
@@ -38,4 +39,7 @@ class NavigationModule {
 
     @Provides
     fun providesAboutNavigator(mainNavigator: MainNavigator): AboutNavigator = mainNavigator
+
+    @Provides
+    fun providesLoginNavigator(mainNavigator: MainNavigator): LoginNavigator = mainNavigator
 }

--- a/app/src/main/java/com/jpp/mp/di/ViewModelModule.kt
+++ b/app/src/main/java/com/jpp/mp/di/ViewModelModule.kt
@@ -7,7 +7,6 @@ import com.jpp.mp.main.MainActivityViewModel
 import com.jpp.mp.main.header.NavigationHeaderViewModel
 import com.jpp.mpaccount.account.UserAccountViewModel
 import com.jpp.mpaccount.account.lists.UserMovieListViewModel
-import com.jpp.mpaccount.login.LoginViewModel
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
@@ -37,10 +36,6 @@ abstract class ViewModelModule {
     /*
      * User account feature dependencies.
      */
-    @Binds
-    @IntoMap
-    @ViewModelKey(LoginViewModel::class)
-    internal abstract fun getLoginViewModel(viewModel: LoginViewModel): ViewModel
 
     @Binds
     @IntoMap

--- a/app/src/main/java/com/jpp/mp/main/MainNavigator.kt
+++ b/app/src/main/java/com/jpp/mp/main/MainNavigator.kt
@@ -6,6 +6,8 @@ import com.jpp.mp.R
 import com.jpp.mp.main.movies.MovieListNavigator
 import com.jpp.mpabout.AboutFragmentDirections
 import com.jpp.mpabout.AboutNavigator
+import com.jpp.mpaccount.login.LoginFragmentDirections
+import com.jpp.mpaccount.login.LoginNavigator
 import com.jpp.mpcredits.CreditNavigator
 import com.jpp.mpcredits.NavigationCredits
 import com.jpp.mpmoviedetails.MovieDetailsFragmentDirections
@@ -24,7 +26,8 @@ class MainNavigator : MovieListNavigator,
     RateMovieNavigator,
     CreditNavigator,
     SearchNavigator,
-    AboutNavigator {
+    AboutNavigator,
+    LoginNavigator {
 
     private var navController: NavController? = null
     private var mainToSearchDelegate: MainToSearchNavigationDelegate? = null
@@ -65,7 +68,7 @@ class MainNavigator : MovieListNavigator,
         )
     }
 
-    override fun navigateToUserAccount() {
+    override fun navigateToLogin() {
         navController?.navigate(
             R.id.user_account_nav,
             null,
@@ -132,6 +135,10 @@ class MainNavigator : MovieListNavigator,
 
     override fun navigateBack() {
         navController?.popBackStack()
+    }
+
+    override fun navigateToUserAccount() {
+        navController?.navigate(LoginFragmentDirections.toAccountFragment())
     }
 
     override fun bind(newNavController: NavController) {

--- a/features/mpaccount/src/main/java/com/jpp/mpaccount/login/LoginFragment.kt
+++ b/features/mpaccount/src/main/java/com/jpp/mpaccount/login/LoginFragment.kt
@@ -1,17 +1,24 @@
 package com.jpp.mpaccount.login
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import com.jpp.mp.common.extensions.observeValue
 import com.jpp.mp.common.extensions.withViewModel
 import com.jpp.mp.common.fragments.MPFragment
+import com.jpp.mp.common.viewmodel.MPGenericSavedStateViewModelFactory
 import com.jpp.mpaccount.R
 import com.jpp.mpaccount.databinding.FragmentLoginBinding
 import com.jpp.mpdesign.ext.snackBarNoAction
+import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.fragment_login.*
+import javax.inject.Inject
 
 /**
  * Fragment used to provide the user a login experience.
@@ -23,28 +30,40 @@ import kotlinx.android.synthetic.main.fragment_login.*
  * The Fragment does not uses DataBinding in order to simplify the URL loading and interception
  * when the login page needs to be shown.
  */
-class LoginFragment : MPFragment<LoginViewModel>() {
+class LoginFragment : Fragment() {
+
+    @Inject
+    lateinit var viewModelFactory: LoginViewModelFactory
 
     private lateinit var viewBinding: FragmentLoginBinding
+
+    private val viewModel: LoginViewModel by viewModels {
+        MPGenericSavedStateViewModelFactory(
+            viewModelFactory,
+            this
+        )
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         viewBinding = DataBindingUtil.inflate(inflater, R.layout.fragment_login, container, false)
         return viewBinding.root
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        withViewModel {
-            viewState.observe(this@LoginFragment.viewLifecycleOwner, Observer { viewState ->
-                viewBinding.viewState = viewState
-
-                if (viewState.oauthViewState.reminder) {
-                    snackBarNoAction(loginContent, R.string.user_account_approve_reminder)
-                }
-            })
-            onInit(getString(R.string.login_generic))
-        }
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
     }
 
-    override fun withViewModel(action: LoginViewModel.() -> Unit) = withViewModel<LoginViewModel>(viewModelFactory) { action() }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.viewState.observeValue(viewLifecycleOwner, ::renderViewState)
+        viewModel.onInit(getString(R.string.login_generic))
+    }
+
+    private fun renderViewState(viewState: LoginViewState) {
+        viewBinding.viewState = viewState
+        if (viewState.oauthViewState.reminder) {
+            snackBarNoAction(loginContent, R.string.user_account_approve_reminder)
+        }
+    }
 }

--- a/features/mpaccount/src/main/java/com/jpp/mpaccount/login/LoginFragment.kt
+++ b/features/mpaccount/src/main/java/com/jpp/mpaccount/login/LoginFragment.kt
@@ -8,10 +8,8 @@ import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import com.jpp.mp.common.extensions.observeValue
-import com.jpp.mp.common.extensions.withViewModel
-import com.jpp.mp.common.fragments.MPFragment
+import com.jpp.mp.common.extensions.setScreenTitle
 import com.jpp.mp.common.viewmodel.MPGenericSavedStateViewModelFactory
 import com.jpp.mpaccount.R
 import com.jpp.mpaccount.databinding.FragmentLoginBinding
@@ -57,10 +55,11 @@ class LoginFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewModel.viewState.observeValue(viewLifecycleOwner, ::renderViewState)
-        viewModel.onInit(getString(R.string.login_generic))
+        viewModel.onInit()
     }
 
     private fun renderViewState(viewState: LoginViewState) {
+        setScreenTitle(getString(viewState.screenTitle))
         viewBinding.viewState = viewState
         if (viewState.oauthViewState.reminder) {
             snackBarNoAction(loginContent, R.string.user_account_approve_reminder)

--- a/features/mpaccount/src/main/java/com/jpp/mpaccount/login/LoginNavigator.kt
+++ b/features/mpaccount/src/main/java/com/jpp/mpaccount/login/LoginNavigator.kt
@@ -1,0 +1,5 @@
+package com.jpp.mpaccount.login
+
+interface LoginNavigator {
+    fun navigateToUserAccount()
+}

--- a/features/mpaccount/src/main/java/com/jpp/mpaccount/login/LoginViewModelFactory.kt
+++ b/features/mpaccount/src/main/java/com/jpp/mpaccount/login/LoginViewModelFactory.kt
@@ -2,6 +2,7 @@ package com.jpp.mpaccount.login
 
 import androidx.lifecycle.SavedStateHandle
 import com.jpp.mp.common.viewmodel.ViewModelAssistedFactory
+import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Inject
 
 /**
@@ -9,9 +10,11 @@ import javax.inject.Inject
  * with the dependencies provided by Dagger.
  */
 class LoginViewModelFactory @Inject constructor(
-    private val loginInteractor: LoginInteractor
+    private val loginInteractor: LoginInteractor,
+    private val loginNavigator: LoginNavigator,
+    private val ioDispatcher: CoroutineDispatcher
 ) : ViewModelAssistedFactory<LoginViewModel> {
     override fun create(handle: SavedStateHandle): LoginViewModel {
-        return LoginViewModel(loginInteractor)
+        return LoginViewModel(loginInteractor, loginNavigator, ioDispatcher)
     }
 }

--- a/features/mpaccount/src/main/java/com/jpp/mpaccount/login/LoginViewModelFactory.kt
+++ b/features/mpaccount/src/main/java/com/jpp/mpaccount/login/LoginViewModelFactory.kt
@@ -1,0 +1,17 @@
+package com.jpp.mpaccount.login
+
+import androidx.lifecycle.SavedStateHandle
+import com.jpp.mp.common.viewmodel.ViewModelAssistedFactory
+import javax.inject.Inject
+
+/**
+ * [ViewModelAssistedFactory] to create specific [LoginViewModel] instances
+ * with the dependencies provided by Dagger.
+ */
+class LoginViewModelFactory @Inject constructor(
+    private val loginInteractor: LoginInteractor
+) : ViewModelAssistedFactory<LoginViewModel> {
+    override fun create(handle: SavedStateHandle): LoginViewModel {
+        return LoginViewModel(loginInteractor)
+    }
+}

--- a/features/mpaccount/src/main/java/com/jpp/mpaccount/login/LoginViewState.kt
+++ b/features/mpaccount/src/main/java/com/jpp/mpaccount/login/LoginViewState.kt
@@ -1,12 +1,14 @@
 package com.jpp.mpaccount.login
 
 import android.view.View
+import com.jpp.mpaccount.R
 import com.jpp.mpdesign.views.MPErrorView.ErrorViewState
 
 /**
  * Represents the view state of the login screen.
  */
 internal data class LoginViewState(
+    val screenTitle: Int = R.string.login_generic,
     val loadingVisibility: Int = View.INVISIBLE,
     val errorViewState: ErrorViewState = ErrorViewState.asNotVisible(),
     val oauthViewState: OauthViewState = OauthViewState()

--- a/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsNavigator.kt
+++ b/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsNavigator.kt
@@ -5,7 +5,7 @@ package com.jpp.mpmoviedetails
  */
 interface MovieDetailsNavigator {
 
-    fun navigateToUserAccount()
+    fun navigateToLogin()
     fun navigateToMovieCredits(
         movieId: Double,
         movieTitle: String

--- a/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsViewModel.kt
+++ b/features/mpmoviedetails/src/main/java/com/jpp/mpmoviedetails/MovieDetailsViewModel.kt
@@ -82,7 +82,7 @@ class MovieDetailsViewModel(
      * Called when the user request to login from the details actions.
      */
     internal fun onUserRequestedLogin() {
-        navigator.navigateToUserAccount()
+        navigator.navigateToLogin()
     }
 
     /**

--- a/features/mpmoviedetails/src/test/java/com/jpp/mpmoviedetails/MovieDetailsViewModelTest.kt
+++ b/features/mpmoviedetails/src/test/java/com/jpp/mpmoviedetails/MovieDetailsViewModelTest.kt
@@ -128,7 +128,7 @@ class MovieDetailsViewModelTest {
     fun `Should navigate to user account when login requested`() {
         subject.onUserRequestedLogin()
 
-        verify { navigator.navigateToUserAccount() }
+        verify { navigator.navigateToLogin() }
     }
 
     @Test


### PR DESCRIPTION
This commit updates `LoginFragment` and `LoginViewModel`
to remove the inheritance from `MPFragment` and `MPViewModel`
respectively. It also introduces a new navigator, `LoginNavigator`,
to handle navigation from the Login section.